### PR TITLE
Gatzeq93/1874 test laravel and php package if it doesnt work add laravel package to docs and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,23 @@
-### Notification-api for Laravel
+# What is NotificationAPI?
 
-Package to use the notification-api Service (https://www.notificationapi.com/) in Laravel Channels and helpers
+With NotificationAPI you can add notifications to your apps in 10 minutes.
 
-Official Doc for Notification Api: https://docs.notificationapi.com/
+Please check our website: [NotificationAPI.com](https://www.notificationapi.com)
 
-## Installation
+# Documentation
 
-To get the latest version of ```notificationapi-laravel-server-sdk``` on your project, require it from "composer":
+Please refer to our hosted [documentations](https://docs.notificationapi.com)
 
+# Contribution
 
-	$ composer require notificationapi/notificationapi-laravel-server-sdk
+Install dependencies:
 
-
-Or you can add it directly in your composer.json file:
-
-```json
-{
-    "require": {
-        "notificationapi/notificationapi-laravel-server-sdk": "1.0"
-    }
-}
+```
 ```
 
+Run tests:
 
-### Config
-
-Register the provider directly in your app configuration file `config/app.php`:
-```php
-'providers' => [
-	// ...
-	
-	NotificationAPI\NotificationApiServiceProvider::class,
-]
+```
 ```
 
-The following lines will be auto added in `config/services.php` by provider.
-
-```php
-return [
-   
-    //...
-    'notification-api' => [
-        'key' => env('NOTIFICATION_API_KEY'),
-        'secret' => env('NOTIFICATION_API_SECRET'),
-    ]
-];
-```
-
-So add the following environment variables in .env file to finish a configuration:
-
-
-```dotenv
-#.env
-NOTIFICATION_API_KEY=clientID
-NOTIFICATION_API_SECRET=clientSecret
-```
-This keys was offered by notification api after register an account
-
-### Using
-Use Artisan to create a notification:
-
-```bash
-php artisan make:notification SomeNotification
-```
-
-Return `[notification-api]` in the `public function via($notifiable)` method of your notification:
-
-```php
-public function via($notifiable)
-{
-    return ['notification-api'];
-}
-```
-
-Add the method `public function toNotificationApi($notifiable)` to your notification:
-
-```php
-//...
-
-public function toNotificationApi($notifiable) 
-{
-    return [
-        "notificationId" => "notification_example",
-        "user" => [
-            "id" => $notifiable->getAttribute('id'),
-            "email" => $notifiable->getAttribute('email'),
-        ],
-        "mergeTags" => [
-            "userName" => auth()->user()->name,
-            "clickAction" => config('app.env')."/example"
-        ]
-    ];
-}
-```
-#### example of notification send
-*Attention: To call notification by the user model, the User model must be "Notifiable" Trait
-
-```php
-    class User extends Authenticatable
-    {
-        use Notifiable;
-        //...
-```
-
-```php
-#notify one user
-$user->notify((new SomeNotification(..)));
-
-#notify multiple users
-Notification::send($users, new SomeNotification(..);
-```
-
-
-
-### Extra: Helpers
-After install and configure we can use the library calling the helper `notification_api` or class `NotificationApiService`
-
-Example:
-
-```php
-$data = [
-  "notificationId" => "order_tracking",
-  "user" => [
-    "id" => "example@mail.com",
-    "email" => "example@mail.com",
-    "number" => "+15005550006"
-  ],
-  "mergeTags" => [
-    "item" => "Krabby Patty Burger",
-    "address" => "124 Conch Street",
-    "orderId" => "1234567890"
-  ]
-];
-
-$result = notification_api($data);
-#or
-$result = (new NotificationApiService)->send($data)
-```
+100% code coverage required.

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^8.1",
-    "illuminate/validation": "^9.19.0",
-    "illuminate/notifications": "~5.3|^6.0|^7.0|^8.0|^9.0",
+    "laravel/framework": "^9.0|^10.0|^11.0",
     "notificationapi/notificationapi-php-server-sdk": "master"
   },
   "extra": {


### PR DESCRIPTION
Ok so  `"illuminate/validation": "^9.19.0"` and  `"illuminate/notifications": "~5.3|^6.0|^7.0|^8.0|^9.0"` were causing issues when installing for any Laravel version over 9.0. Turns out we don't need `illuminate/validation` at all (its not in the code) but `illuminate/notifications` still caused issues since `laravel/framework` replaces `illuminate/notifications`. 

In short, removing those two dependencies and instead relying on Larevel itself allows the developer to install this package for any Larevel package version 9 and up. Tested this locally with `composer` and symlinks but should still be fine.

I'll reach out to Nairan though to make sure this is fine before merging.